### PR TITLE
Remove duplicate ProfilesController method, add NotImplementedExceptions

### DIFF
--- a/Using OAuth to Secure Your ASP.NET API/SocialNetwork.Api/Controllers/ProfilesController.cs
+++ b/Using OAuth to Secure Your ASP.NET API/SocialNetwork.Api/Controllers/ProfilesController.cs
@@ -39,26 +39,6 @@ namespace SocialNetwork.Api.Controllers
             return Ok(profile);
         }
 
-        [HttpGet]
-        public async Task<IHttpActionResult> GetAsync(string username, string password)
-        {
-            var user = await userRepository.GetAsync(username, HashHelper.Sha512(password + username));
-
-            if (user == null)
-            {
-                return NotFound();
-            }
-
-            var profile = await profileRepository.GetForAsync(user);
-
-            if (profile == null)
-            {
-                return NotFound();
-            }
-
-            return Ok(profile);
-        }
-
         [HttpPut]
         public async Task<IHttpActionResult> PutAsync(string username, string password, [FromBody]Profile profile)
         {

--- a/Using OAuth to Secure Your ASP.NET API/SocialNetwork.OAuth/Configuration/Clients.cs
+++ b/Using OAuth to Secure Your ASP.NET API/SocialNetwork.OAuth/Configuration/Clients.cs
@@ -2,6 +2,7 @@
 using System.Security.Claims;
 using IdentityServer3.Core;
 using IdentityServer3.Core.Models;
+using System;
 
 namespace SocialNetwork.OAuth.Configuration
 {
@@ -9,6 +10,7 @@ namespace SocialNetwork.OAuth.Configuration
     {
         public static IEnumerable<Client> GetClients()
         {
+            throw new NotImplementedException();
             //TODO: Add clients
         }
     }

--- a/Using OAuth to Secure Your ASP.NET API/SocialNetwork.OAuth/Configuration/Scopes.cs
+++ b/Using OAuth to Secure Your ASP.NET API/SocialNetwork.OAuth/Configuration/Scopes.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using IdentityServer3.Core.Models;
+using System;
 
 namespace SocialNetwork.OAuth.Configuration
 {
@@ -7,6 +8,7 @@ namespace SocialNetwork.OAuth.Configuration
     {
         public static IEnumerable<Scope> GetScopes()
         {
+            throw new NotImplementedException();
             //TODO: Add Scopes
         }
     }

--- a/Using OAuth to Secure Your ASP.NET API/SocialNetwork.OAuth/Configuration/Users.cs
+++ b/Using OAuth to Secure Your ASP.NET API/SocialNetwork.OAuth/Configuration/Users.cs
@@ -2,6 +2,7 @@
 using System.Security.Claims;
 using IdentityServer3.Core;
 using IdentityServer3.Core.Services.InMemory;
+using System;
 
 namespace SocialNetwork.OAuth.Configuration
 {
@@ -9,6 +10,7 @@ namespace SocialNetwork.OAuth.Configuration
     {
         public static List<InMemoryUser> GetUsers()
         {
+            throw new NotImplementedException();
             //TODO: Add Users
         }
     }


### PR DESCRIPTION
Remove duplicated ProfilesController.GetAsync method.

Throw new NotImplementedExceptions in empty methods in the
SocialNetwork.OAuth.Configuration namespace to prevent compile errors.

fixes issue #1 
